### PR TITLE
📝 docs(README.md): add installation instructions for stable and devel…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # PKT Starter Kit
 ## Installation
 
+For stable package install using
+```bash
+composer require pkt/starter-kit --dev 
+```
+
+For development this package install using
 ```bash
 composer require pkt/starter-kit:dev-dev --dev 
 ```


### PR DESCRIPTION
…opment packages

The installation instructions in the README.md file have been updated to include separate instructions for installing the stable package and the development package. The stable package can now be installed using the command `composer require pkt/starter-kit --dev`, while the development package can be installed using `composer require pkt/starter-kit:dev-dev --dev`.