### PR TITLE
📝 docs(README.md): add instructions to enable SSL using a2enmod command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ services:
    ```cmd
    docker exec -it <container_name> bash
    ```
+### SSL (HTTPS) 
+If SSL is disabled, enable SSL using
+```cmd
+a2enmod ssl
+```
 
 ### Worker using supervisor
 Available supervisor worker located in `/etc/supervisor/conf.d/laravel-worker.conf`


### PR DESCRIPTION
The README file was updated to include instructions on how to enable SSL using the `a2enmod` command. This change was made to provide users with a clear and concise way to enable SSL for their application.