### PR TITLE
Dev 2

### DIFF
--- a/resource-template/vue/resources/js/Pages/IndexPage.vue
+++ b/resource-template/vue/resources/js/Pages/IndexPage.vue
@@ -59,11 +59,11 @@
             </DxDataGrid>
         </div>
 
-        <!-- MODAL TAMBAH EDIT -->
+        <!-- MODAL CREATE & EDIT -->
         <el-dialog v-model="dialogFormVisible" width="500px" :append-to-body="true" :destroy-on-close="true"
             class="!rounded-xl">
             <template #header>
-                <span class="font-bold text-lg">{{ !editMode ? 'Tambah' : 'Edit' }} ModelLabel</span>
+                <span class="font-bold text-lg">{{ !editMode ? 'Create' : 'Edit' }} ModelLabel</span>
             </template>
             <el-form ref="formModelNameRef" :model="formModelName" label-width="200px" label-position="top"
                 require-asterisk-position="right" autocomplete="off">

--- a/stubs/vue/resources/js/Components/BsProfilePicture.vue
+++ b/stubs/vue/resources/js/Components/BsProfilePicture.vue
@@ -1,12 +1,17 @@
 <template>
     <img src="/images/avatar-default.png" class="bg-[#e4e4e5]" name="profile-picture" alt="profile-picture" v-if="pictNotFound"/>
-    <img :src="'https://leader.pupukkaltim.com/public/foto-thumbnail/'+user.npk+'.jpg'" @error="()=>pictNotFound=true" class="bg-[#e4e4e5]" name="profile-picture" alt="profile-picture" v-else/>
+    <img :src="'https://leader.pupukkaltim.com/public/foto-thumbnail/'+props.npk+'.jpg'" @error="()=>pictNotFound=true" class="bg-[#e4e4e5]" name="profile-picture" alt="profile-picture" v-else/>
 </template>
 <script setup>
-import { usePage } from '@inertiajs/vue3';
 import { ref } from 'vue';
 
+const props = defineProps({
+    npk:{
+        type: String,
+        required: false
+    }
+});
+
 var pictNotFound = ref(false);
-var user = ref(usePage().props.auth.user);
 
 </script>

--- a/stubs/vue/resources/js/Layouts/Components/Header.vue
+++ b/stubs/vue/resources/js/Layouts/Components/Header.vue
@@ -19,7 +19,7 @@
                     </button>
                     <button class="group text-start">
                         <div class="shrink-0 rounded-lg py-2 px-5 border-2 border-[#f1f4f6] flex align-middle items-center bg-white group-hover:bg-primary-surface cursor-pointer">
-                            <BsProfilePicture class="w-7 h-7 md:mr-2 rounded-full"/>
+                            <BsProfilePicture class="w-10 h-10 md:mr-2 rounded-full shadow-lg" :npk="user.npk"/>
                             <div class="hidden md:flex items-center">
                                 <div class=" flex flex-col text-gray-900">
                                     <div class="w-32 truncate text-xs font-bold">{{ $page.props.auth.user.name }}</div>
@@ -63,7 +63,7 @@
 <script setup>
 import { ref, computed } from 'vue';
 import BsIcon from '@/Components/BsIcon.vue';
-import { Link } from '@inertiajs/vue3';
+import { Link, usePage } from '@inertiajs/vue3';
 import { useSidemenuStore } from '@/Stores/sidemenu';
 import BsProfilePicture from '@/Components/BsProfilePicture.vue';
 
@@ -74,4 +74,6 @@ const sidemenu = computed(()=>sideMenuStore.sidemenu);
 
 const toggleSideMenu = sideMenuStore.toggleSidemenu;
 const toggleDrawer = sideMenuStore.toggleDrawer;
+
+var user = ref(usePage().props.auth.user);
 </script>

--- a/stubs/vue/resources/js/Pages/Account.vue
+++ b/stubs/vue/resources/js/Pages/Account.vue
@@ -14,7 +14,7 @@
                 <div>
                     <div class="grid grid-cols-12 grid-flow-row-dense gap-4">
                         <div class="col-span-12 lg:col-span-3 p-4">
-                            <BsProfilePicture/>
+                            <BsProfilePicture :npk="user.npk"/>
                         </div>
                         <div class="col-span-12 lg:col-span-9 p-4">
                             <table class="w-full">
@@ -32,11 +32,11 @@
                                 </tr>
                                 <tr>
                                     <td class="font-bold w-60">Departement</td>
-                                    <td>{{ '-' }}</td>
+                                    <td>{{ user.position ?? '-' }}</td>
                                 </tr>
                                 <tr>
-                                    <td class="font-bold w-60">Jabatan</td>
-                                    <td>{{ '-' }}</td>
+                                    <td class="font-bold w-60">Position</td>
+                                    <td>{{ user.work_unit ?? '-' }}</td>
                                 </tr>
                                 <tr>
                                     <td class="font-bold w-60">Role</td>

--- a/stubs/vue/resources/js/Pages/User/RoleAndPermissionManage.vue
+++ b/stubs/vue/resources/js/Pages/User/RoleAndPermissionManage.vue
@@ -98,9 +98,7 @@
                                     <el-tab-pane label="User" name="user">
                                         <div v-for="user in roleUsers">
                                             <div class="shrink-0 rounded-lg py-2 px-5 border-2 border-[#f1f4f6] flex align-middle items-center bg-white group-hover:bg-primary-surface cursor-pointer mt-2">
-                                                <div class="bg-[#e4e4e5] p-4 w-10 h-10 rounded-full text-gray-800 font-bold flex items-center justify-center mr-2">
-                                                    {{ user.name.charAt(0).toUpperCase() }}
-                                                </div>
+                                                <BsProfilePicture :npk="user.npk" class="w-10 h-10 rounded-full shadow-lg mr-2" />
                                                 <div class="flex items-center">
                                                     <div class=" flex flex-col text-gray-900">
                                                         <div class="w-32 truncate text-md font-bold">{{ user.name }}</div>
@@ -150,6 +148,7 @@ import { Head, usePage, router, useForm } from '@inertiajs/vue3';
 import { ref, computed, reactive } from 'vue';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import { can } from '@/Core/Helpers/permission-check';
+import BsProfilePicture from '@/Components/BsProfilePicture.vue';
 
 // CRUD user role
 const dialogFormRoleVisible = ref(false);

--- a/stubs/vue/resources/js/Pages/User/UserManage.vue
+++ b/stubs/vue/resources/js/Pages/User/UserManage.vue
@@ -101,7 +101,7 @@
         <el-dialog v-model="dialogFormVisible" width="500px" :append-to-body="true" :destroy-on-close="true"
             class="!rounded-xl">
             <template #header>
-                <span class="font-bold text-lg">{{ !editMode ? 'Tambah' : 'Edit' }} User</span>
+                <span class="font-bold text-lg">{{ !editMode ? 'Create' : 'Edit' }} User</span>
             </template>
             <el-form ref="formUserRef" :model="formUser" label-width="200px" label-position="top"
                 require-asterisk-position="right" autocomplete="off">


### PR DESCRIPTION
🐛 fix(IndexPage.vue): update modal header text from 'Tambah' and 'Edit' to 'Create' and 'Edit' for better clarity

🐛 fix(BsProfilePicture.vue): update user.npk reference to props.npk to fix incorrect profile picture source
🐛 fix(Header.vue): update BsProfilePicture component usage to pass user.npk as a prop for correct profile picture display
🐛 fix(Account.vue): update BsProfilePicture component usage to pass user.npk as a prop for correct profile picture display
🐛 fix(RoleAndPermissionManage.vue): update BsProfilePicture component usage to pass user.npk as a prop for correct profile picture display
🐛 fix(UserManage.vue): update modal header text from 'Tambah' and 'Edit' to 'Create' and 'Edit' for better clarity