### PR TITLE
🐛 fix(MakeViewCommand.php): fix incorrect variable name in replaceCon…

### DIFF
--- a/database-view-stubs/migrations/create_view_table.php
+++ b/database-view-stubs/migrations/create_view_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $query = ModelName::query();
+        $query = \App\Models\ModelName::query();
         FacadesSchema::createView('table_name', $query);
     }
 

--- a/src/Console/MakeViewCommand/MakeViewCommand.php
+++ b/src/Console/MakeViewCommand/MakeViewCommand.php
@@ -50,7 +50,7 @@ class MakeViewCommand extends Command implements PromptsForMissingInput
         ]);
 
         copy(__DIR__.'/../../../database-view-stubs/migrations/create_view_table.php', $migrationPath);
-        $this->replaceContent($path, [
+        $this->replaceContent($migrationPath, [
             'ModelName' => $modelName,
             'table_name' => $viewName,
         ]);

--- a/src/Console/MakeViewCommand/MakeViewCommand.php
+++ b/src/Console/MakeViewCommand/MakeViewCommand.php
@@ -15,7 +15,8 @@ class MakeViewCommand extends Command implements PromptsForMissingInput
      * @var string
      */
     protected $signature = 'pkt:make-view
-        {name : The name of the view model}';
+        {name : The name of the view model}
+        {--model= : The name of the related model}';
 
     /**
      * The console command description.
@@ -31,7 +32,6 @@ class MakeViewCommand extends Command implements PromptsForMissingInput
      */
     public function handle()
     {
-        
         $modelName = $this->argument('name');
         $path = app_path('Models/Views/' . $modelName);
         $viewName = Str::snake(Str::pluralStudly($modelName));
@@ -49,9 +49,10 @@ class MakeViewCommand extends Command implements PromptsForMissingInput
             'table_name' => $viewName,
         ]);
 
+        $relatedModel = $this->option('model') ?? $modelName;
         copy(__DIR__.'/../../../database-view-stubs/migrations/create_view_table.php', $migrationPath);
         $this->replaceContent($migrationPath, [
-            'ModelName' => $modelName,
+            'ModelName' => $relatedModel,
             'table_name' => $viewName,
         ]);
         


### PR DESCRIPTION
…tent method call

The variable name passed to the `replaceContent` method call was incorrect, causing the content replacement to fail. This has been fixed by using the correct variable name `$migrationPath` instead of `$path`.