### PR TITLE
🔥 refactor(InstallCommand.php): remove unnecessary call to publishCon…

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -207,7 +207,6 @@ class InstallCommand extends Command implements PromptsForMissingInput
 
             // Reverb
             $this->addEnvironmentVariables();
-            $this->publishConfiguration();
             $this->updateBroadcastingConfiguration();
             $this->enableBroadcasting();
             // End Reverb


### PR DESCRIPTION
…figuration() method

The call to the `publishConfiguration()` method was removed as it was no longer needed and was causing unnecessary overhead.