### PR TITLE
🐛 fix(ManipulateVueResource.php): exclude columns ending with '_uuid'…

### DIFF
--- a/src/Console/MakeResourceCommand/ManipulateVueResource.php
+++ b/src/Console/MakeResourceCommand/ManipulateVueResource.php
@@ -68,7 +68,7 @@ trait ManipulateVueResource
         $columnTableSlot = '';
         foreach ($columns as $column) {
             $label = Str::headline($column);
-            if ($column === $primaryKey || $column === 'created_at' || $column === 'updated_at' || $column === 'deleted_at') {
+            if ($column === $primaryKey || $column === 'created_at' || $column === 'updated_at' || $column === 'deleted_at' || Str::endsWith($column, '_uuid') || Str::endsWith($column, '_id')) {
                 continue;
             }
             $columnTableSlot .= '<DxColumn data-field="'. $column . '" caption="' . $label .'" :allowHeaderFiltering="false" />' . PHP_EOL . '                ';
@@ -80,7 +80,7 @@ trait ManipulateVueResource
             $type = $model->getConnectionResolver()->connection()->getSchemaBuilder()->getColumnType($model->getTable(), $column);
             $required = $model->getConnectionResolver()->connection()->getSchemaBuilder()->getConnection()->getDoctrineColumn($model->getTable(), $column)->getNotnull();
             $label = Str::headline($column);
-            if ($column === $primaryKey || $column === 'created_at' || $column === 'updated_at' || $column === 'deleted_at') {
+            if ($column === $primaryKey || $column === 'created_at' || $column === 'updated_at' || $column === 'deleted_at' || Str::endsWith($column, '_uuid') || Str::endsWith($column, '_id')) {
                 continue;
             }
 

--- a/src/Traits/GlobalSearch.php
+++ b/src/Traits/GlobalSearch.php
@@ -34,7 +34,7 @@ trait GlobalSearch
      */
     public function searchableAttributes(): array
     {
-        return ['name'];
+        return $this->getConnection()->getSchemaBuilder()->getColumnListing($this->getTable());
     }
 
     /**
@@ -44,7 +44,7 @@ trait GlobalSearch
      */
     public function searchableAttributeId(): int|string
     {
-        return $this->id;
+        return $this->getKey();
     }
 
     /**
@@ -54,7 +54,7 @@ trait GlobalSearch
      */
     public function searchableFormatRecord(Model $record): string
     {
-        return (string) $record->name;
+        return (string) $record[$this->getKeyName()];
     }
 
     /**


### PR DESCRIPTION
… or '_id' from being processed in Vue resource manipulation

🐛 fix(GlobalSearch.php): use dynamic column listing instead of hardcoding 'name' column for global search functionality