### PR TITLE
🐛 fix(StarterKitServiceProvider.php): fix method calls to use foreign…

### DIFF
--- a/src/StarterKitServiceProvider.php
+++ b/src/StarterKitServiceProvider.php
@@ -41,8 +41,8 @@ class StarterKitServiceProvider extends ServiceProvider implements DeferrablePro
         ]);
 
         Blueprint::macro('createdUpdatedBy', function () {
-            $this->foreignIdBy(config('auth.providers.users.model'), 'created_by')->nullable();
-            $this->foreignIdBy(config('auth.providers.users.model'), 'updated_by')->nullable();
+            $this->foreignIdFor(config('auth.providers.users.model'), 'created_by')->nullable();
+            $this->foreignIdFor(config('auth.providers.users.model'), 'updated_by')->nullable();
         });
     }
 


### PR DESCRIPTION
…IdFor instead of foreignIdBy to match Laravel Blueprint syntax