### PR TITLE
🐛 fix(InitMediaCommand.php): fix typo in migration file name to ensur…

### DIFF
--- a/src/Console/MediaCommand/InitMediaCommand.php
+++ b/src/Console/MediaCommand/InitMediaCommand.php
@@ -55,8 +55,8 @@ class InitMediaCommand extends Command implements PromptsForMissingInput
             if (!file_exists(database_path('migrations/2024_06_11_000000_create_media_table.php'))) {
                 copy(__DIR__.'/../../../media-stubs/database/migrations/2024_06_11_000000_create_media_table.php', database_path('migrations/2024_06_11_000000_create_media_table.php'));
             }
-            if (!file_exists(database_path('migrations/2024_06_11_00000_create_mediables_table.php'))) {
-                copy(__DIR__.'/../../../media-stubs/database/migrations/2024_06_11_00000_create_mediables_table.php', database_path('migrations/2024_06_11_00000_create_mediables_table.php'));
+            if (!file_exists(database_path('migrations/2024_06_11_000000_create_mediables_table.php'))) {
+                copy(__DIR__.'/../../../media-stubs/database/migrations/2024_06_11_000000_create_mediables_table.php', database_path('migrations/2024_06_11_00000_create_mediables_table.php'));
             }
         });
 


### PR DESCRIPTION
…e correct file is copied