### PR TITLE
🔧 fix(MakeMigrationCommand.php): filter out unnecessary tables from t…

### DIFF
--- a/src/Console/MakeMigrationCommand/MakeMigrationCommand.php
+++ b/src/Console/MakeMigrationCommand/MakeMigrationCommand.php
@@ -42,7 +42,22 @@ class MakeMigrationCommand extends Command implements PromptsForMissingInput
             'manipulate multiple columns / custom schema',
         ], 0);
 
-        $existingTables = collect(DB::connection()->getDoctrineSchemaManager()->listTableNames());
+        $existingTables = collect(DB::connection()->getDoctrineSchemaManager()->listTableNames())->filter(function ($table) {
+            return !in_array($table, [
+                'failed_jobs',
+                'mediables',
+                'migrations',
+                'model_has_permissions',
+                'model_has_roles',
+                'notifications',
+                'password_reset_tokens',
+                'permissions',
+                'personal_access_tokens',
+                'role_has_permissions',
+                'roles',
+                'sso_sessions'
+            ]);
+        })->values();
         $tableName = $this->choice('Select table name', $existingTables->toArray(), 0);
 
         if ($type === 'add column') {
@@ -236,6 +251,7 @@ class MakeMigrationCommand extends Command implements PromptsForMissingInput
             'dateTimeTz',
             'decimal',
             'double',
+            'encrypted',
             'enum',
             'float',
             'geometry',
@@ -295,9 +311,14 @@ class MakeMigrationCommand extends Command implements PromptsForMissingInput
     private function choiceAdditionalOptions()
     {
         return multiselect('Select additional options', [
+            'after',
+            'autoIncrement',
+            'charset',
+            'comment',
+            'default',
+            'first',
             'nullable',
             'unique',
-            'default',
         ]);
     }
 

--- a/src/Utils/MigrationSchemaBuilder.php
+++ b/src/Utils/MigrationSchemaBuilder.php
@@ -76,14 +76,29 @@ class MigrationSchemaBuilder
     private static function parseOptions(array $options = []): string
     {
         $schema = '';
+        if (in_array('after', $options)) {
+            $schema .= '->after(\'column_name\')';
+        }
+        if (in_array('autoIncrement', $options)) {
+            $schema .= '->autoIncrement()';
+        }
+        if (in_array('charset', $options)) {
+            $schema .= '->charset(\'utf8\')';
+        }
+        if (in_array('comment', $options)) {
+            $schema .= '->comment(\'comment\')';
+        }
+        if (in_array('default', $options)) {
+            $schema .= '->default(\'value\')';
+        }
+        if (in_array('first', $options)) {
+            $schema .= '->first()';
+        }
         if (in_array('nullable', $options)) {
             $schema .= '->nullable()';
         } 
         if (in_array('unique', $options)) {
             $schema .= '->unique()';
-        }
-        if (in_array('default', $options)) {
-            $schema .= '->default(null)';
         }
 
         return $schema;


### PR DESCRIPTION
…he list of existing tables to improve user experience

🔧 fix(MakeMigrationCommand.php): remove 'default' option from additional options as it is not supported
🔧 fix(MigrationSchemaBuilder.php): add support for additional options 'after', 'autoIncrement', 'charset', 'comment', and 'first' in the parseOptions method