### PR TITLE
🐛 fix(MakeMailCommand.php): fix file paths for copying mail stubs to …

### DIFF
--- a/src/Console/MailCommand/MakeMailCommand.php
+++ b/src/Console/MailCommand/MakeMailCommand.php
@@ -36,8 +36,8 @@ class MakeMailCommand extends Command implements PromptsForMissingInput
 
         (new Filesystem)->ensureDirectoryExists(resource_path('views/mails'));
         (new Filesystem)->ensureDirectoryExists(app_path('Mail'));
-        copy(__DIR__ . '/../../mail-stubs/app/Mail/Mail.php', app_path("Mail/{$name}.php"));
-        copy(__DIR__ . '/../../mail-stubs/resources/views/mails/mail.blade.php', resource_path("views/mails/{$view}.blade.php"));
+        copy(__DIR__ . '/../../../mail-stubs/app/Mail/Mail.php', app_path("Mail/{$name}.php"));
+        copy(__DIR__ . '/../../../mail-stubs/resources/views/mails/mail.blade.php', resource_path("views/mails/{$view}.blade.php"));
 
         $subject = Str::title($name);
         $this->replaceContent(app_path("Mail/{$name}.php"), [


### PR DESCRIPTION
…correct locations