### PR TITLE
🔒 chore(StarterEnvironmentDecryptCommand.php): refactor handle method…

### DIFF
--- a/src/Console/StarterEnvironmentDecryptCommand.php
+++ b/src/Console/StarterEnvironmentDecryptCommand.php
@@ -32,9 +32,14 @@ class StarterEnvironmentDecryptCommand extends Command implements PromptsForMiss
      */
     public function handle()
     {
+        $key = $this->option('key');
+        if (!$key) {
+            $key = $this->ask('Enter the encryption key');
+        }
+
         copy(__DIR__ . '/../../stubs/default/.env.starter.encrypted', '.env.starter.encrypted');
         $this->call('env:decrypt', [
-            '--key' => $this->option('key'),
+            '--key' => $key,
             '--cipher' => $this->option('cipher'),
             '--env' => 'starter',
             '--force' => $this->option('force'),


### PR DESCRIPTION
… to prompt for encryption key if not provided as an option

🔒 chore(StarterEnvironmentDecryptCommand.php): use the provided encryption key if available, otherwise prompt for it