### PR TITLE
🔧 chore(GUIDE.md): add missing import for Attachment class in App\Mai…

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -544,6 +544,7 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;


### PR DESCRIPTION
…l namespace

📝 docs(GUIDE.md): update guide to include information about using the Attachment class in the App\Mail namespace