### PR TITLE
🔧 chore(RegenerateEncryptedDataCommand.php): add new command to regen…

### DIFF
--- a/src/Console/RegenerateEncryptedDataCommand.php
+++ b/src/Console/RegenerateEncryptedDataCommand.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Pkt\StarterKit\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\PromptsForMissingInput;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Pkt\StarterKit\Casts\Encrypted;
+use Pkt\StarterKit\Helpers\Crypt;
+
+class RegenerateEncryptedDataCommand extends Command implements PromptsForMissingInput
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'pkt:regenerate-encrypted-data
+                    {--generate : Automatically regenerate the encryption key and iv}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Regenerate encrypted data in the database';
+
+    /**
+     * The new crypt key.
+     *
+     * @var string
+     */
+    private $newCryptKey;
+
+    /**
+     * The new crypt iv.
+     *
+     * @var string
+     */
+    private $newCryptIv;
+
+    /**
+     * Execute the console command.
+     *
+     * @return int|null
+     */
+    public function handle()
+    {
+        if (
+            !config('crypt.regenerate') || 
+            (config('crypt.key') === null || config('crypt.iv') === null) || 
+            (!$this->option('generate') && 
+                (!config('crypt.previous_key') || !config('crypt.previous_iv'))
+            )
+        ){
+            $this->error('The encryption key and iv cannot be regenerated.');
+            return 0;
+        }
+
+        $envKey = $this->ask('What is the encryption key in your .env file?');
+        if ($envKey !== config('crypt.key')) {
+            $this->error('The encryption key is not the same as the one in your .env file.');
+            return 0;
+        }
+
+        $confirmation = $this->confirm('Are you sure you want to regenerate the encrypted data in the database?');
+        if (!$confirmation) {
+            $this->info('The encrypted data in the database was not regenerated.');
+            return 0;
+        }
+
+        $this->newCryptKey = Str::random(32);
+        $this->newCryptIv = Str::random(16);
+
+        DB::beginTransaction();
+        try {
+            $files = File::allFiles(app_path('Models'));
+            foreach ($files as $file) {
+                $model = 'App\\Models\\' . str_replace('/', '\\', str_replace('.php', '', $file->getRelativePathname()));
+                $model = new $model;
+
+                $casts = $model->getCasts();
+                $encryptedColumns = [];
+
+                foreach ($casts as $key => $value) {
+                    if (str_contains($value, Encrypted::class)) {
+                        $encryptedColumns[] = $key;
+                    }
+                }
+                if (count($encryptedColumns) > 0) {
+                    $this->reEncryptData($model, $encryptedColumns);
+                }
+            }
+        } catch (\Exception $e) {
+            DB::rollBack();
+            throw $e;
+        }
+        DB::commit();
+        if ($this->option('generate')) {
+            $this->replaceCryptKeyAndIv();
+        }
+        return 1;
+    }
+
+    /**
+     * Replace the old crypt key and iv with the new crypt key and iv.
+     * Also, set the old crypt key and iv as previous key and iv.
+     * This will change the .env file.
+     *
+     * @return void
+     */
+    private function replaceCryptKeyAndIv(): void
+    {
+        $envFile = base_path('.env');
+
+        $oldCryptKey = config('crypt.key');
+        $oldCryptIv = config('crypt.iv');
+
+        $newCryptKey = $this->newCryptKey;
+        $newCryptIv = $this->newCryptIv;
+
+        $envContent = file_get_contents($envFile);
+        if (str_contains($envContent, 'CRYPT_PREVIOUS_KEY')) {
+
+            $envContent = str_replace($oldCryptKey, $newCryptKey, $envContent);
+            $envContent = str_replace($oldCryptIv, $newCryptIv, $envContent);
+            $envContent = preg_replace('/CRYPT_PREVIOUS_KEY=(.*)/', 'CRYPT_PREVIOUS_KEY=' . $oldCryptKey, $envContent);
+            $envContent = preg_replace('/CRYPT_PREVIOUS_IV=(.*)/', 'CRYPT_PREVIOUS_IV=' . $oldCryptIv, $envContent);
+        } else {
+            $envCryptKey = $newCryptKey . "\nCRYPT_PREVIOUS_KEY=" . $oldCryptKey;
+            $envCryptIv = $newCryptIv . "\nCRYPT_PREVIOUS_IV=" . $oldCryptIv;
+
+            $envContent = str_replace($oldCryptKey, $envCryptKey, $envContent);
+            $envContent = str_replace($oldCryptIv, $envCryptIv, $envContent);
+        }
+
+        file_put_contents($envFile, $envContent);
+    }
+
+    /**
+     * Re-encrypt the data in the database.
+     *
+     * @param string $model
+     * @param array $encryptedColumns
+     *
+     * @return void
+     */
+    private function reEncryptData($model, $encryptedColumns): void
+    {
+        DB::beginTransaction();
+        try {
+            $model::query()->lockForUpdate()->chunk(100, function ($models) use ($encryptedColumns) {
+                foreach ($models as $model) {
+                    foreach ($encryptedColumns as $column) {
+                        $model->withCasts([$column => 'string']);
+                        if ($model->{$column} === null) {
+                            continue;
+                        }
+                        if ($this->option('generate')) {
+                            $columnData = Crypt::decrypt($model->{$column}, config('crypt.cipher'), config('crypt.iv'), config('crypt.key'));
+                            $model->{$column} = Crypt::encrypt($columnData, config('crypt.cipher'), $this->newCryptIv, $this->newCryptKey);
+                        } else {
+                            $columnData = Crypt::decrypt($model->{$column}, config('crypt.cipher'), config('crypt.previous_iv'), config('crypt.previous_key'));
+                            $model->{$column} = Crypt::encrypt($columnData, config('crypt.cipher'), config('crypt.iv'), config('crypt.key'));
+                        }
+                    }
+                    $model->updateQuietly();
+                }
+            });
+        } catch (\Exception $e) {
+            DB::rollBack();
+            throw $e;
+        }
+        DB::commit();
+    }
+}

--- a/src/StarterKitServiceProvider.php
+++ b/src/StarterKitServiceProvider.php
@@ -42,6 +42,7 @@ class StarterKitServiceProvider extends ServiceProvider implements DeferrablePro
             Console\MailCommand\InitMailCommand::class,
             Console\MailCommand\MakeMailCommand::class,
             Console\StarterEnvironmentDecryptCommand::class,
+            Console\RegenerateEncryptedDataCommand::class,
         ]);
     }
 
@@ -66,6 +67,7 @@ class StarterKitServiceProvider extends ServiceProvider implements DeferrablePro
             Console\MailCommand\InitMailCommand::class,
             Console\MailCommand\MakeMailCommand::class,
             Console\StarterEnvironmentDecryptCommand::class,
+            Console\RegenerateEncryptedDataCommand::class,
         ];
     }
 }

--- a/stubs/default/config/crypt.php
+++ b/stubs/default/config/crypt.php
@@ -17,7 +17,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Default encryption key
+    | Encryption key
     |--------------------------------------------------------------------------
     |
     | This option defines the default encryption key that gets used when encrypting
@@ -32,7 +32,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Default encryption iv
+    | Encryption iv
     |--------------------------------------------------------------------------
     |
     | This option defines the default encryption iv that gets used when encrypting and
@@ -44,6 +44,19 @@ return [
     'iv' => env('CRYPT_IV', null),
 
     'previous_iv' => env('CRYPT_PREVIOUS_IV', env('CRYPT_IV', null)),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enable regenerating encryption key and iv
+    |--------------------------------------------------------------------------
+    |
+    | This option defines whether the encryption key and iv can be regenerated
+    | or not. If set to true, the encryption key and iv can be regenerated.
+    | If set to false, the encryption key and iv cannot be regenerated.
+    |
+    */
+
+    'regenerate' => env('CRYPT_REGENERATE', false),
     
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
…erate encrypted data in the database

🔧 chore(StarterKitServiceProvider.php): register RegenerateEncryptedDataCommand in the service provider
🔧 chore(config/crypt.php): add 'regenerate' option to enable or disable regeneration of encryption key and iv

The changes were made to add a new command called RegenerateEncryptedDataCommand. This command allows the user to regenerate encrypted data in the database. The command prompts the user for the encryption key in the .env file and confirms if they want to regenerate the encrypted data. If the user confirms, the command generates new encryption key and iv, and re-encrypts the data in the database using the new key and iv. The old key and iv are replaced with the new key and iv in the .env file. The command also checks for the 'regenerate' option in the crypt configuration file to determine if the encryption key and iv can be regenerated or not. The RegenerateEncryptedDataCommand is registered in the StarterKitServiceProvider to make it available as a console command.