### PR TITLE
🐛 fix(RegenerateEncryptedDataCommand.php): fix prompt messages for en…

### DIFF
--- a/stubs/default/config/crypt.php
+++ b/stubs/default/config/crypt.php
@@ -28,7 +28,7 @@ return [
 
     'key' => env('CRYPT_KEY', null),
 
-    'previous_key' => env('CRYPT_PREVIOUS_KEY', env('CRYPT_KEY', null)),
+    'previous_key' => env('CRYPT_PREVIOUS_KEY', null),
 
     /*
     |--------------------------------------------------------------------------
@@ -43,7 +43,7 @@ return [
 
     'iv' => env('CRYPT_IV', null),
 
-    'previous_iv' => env('CRYPT_PREVIOUS_IV', env('CRYPT_IV', null)),
+    'previous_iv' => env('CRYPT_PREVIOUS_IV', null),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
…cryption key and iv to match the correct values in the .env file

✨ feat(RegenerateEncryptedDataCommand.php): add support for re-encrypting data in the database using the previous encryption key and iv
✨ feat(RegenerateEncryptedDataCommand.php): display table with the names of tables and their corresponding encrypted columns after re-encryption
✨ feat(RegenerateEncryptedDataCommand.php): add info message to indicate that the encrypted data in the database has been regenerated
🐛 fix(crypt.php): fix default values for previous_key and previous_iv to be null instead of using the current key and iv values from the .env file