### PR TITLE
🔥 refactor(InstallCommand.php): remove unused code for creating and c…

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -135,9 +135,9 @@ class InstallCommand extends Command implements PromptsForMissingInput
 
             // End Controllers
 
-            // Helpers
-            (new Filesystem)->ensureDirectoryExists(app_path('Http/Helpers'));
-            (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/default/app/Http/Helpers', app_path('Http/Helpers'));
+            // Helpers (Not used)
+            // (new Filesystem)->ensureDirectoryExists(app_path('Http/Helpers'));
+            // (new Filesystem)->copyDirectory(__DIR__.'/../../stubs/default/app/Http/Helpers', app_path('Http/Helpers'));
             // End Helpers
 
             // Middleware


### PR DESCRIPTION
…opying helper files

The code for creating and copying helper files was commented out as it is not being used in the application. This change removes the commented code to improve code readability and maintainability.